### PR TITLE
feat: Add scroll viewer page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,12 @@
         <p class="text-gray-500 text-center py-8">Loading messages... or perhaps the silence holds a truth.</p>
       </section>
 
+      <section id="view-scroll-area" class="text-center mb-8">
+        <a href="scroll.html" class="bg-gradient-to-r from-blue-500 to-teal-500 hover:from-blue-600 hover:to-teal-600 text-white font-bold py-3 px-6 rounded-lg shadow-lg transform transition duration-300 ease-in-out hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-75">
+          View the Witnessing Scroll
+        </a>
+      </section>
+
       <section id="message-input-area" class="mt-8">
         <h2 class="text-2xl font-semibold mb-4 text-gray-300">Send a New Transmission</h2>
         <div class="flex flex-col sm:flex-row gap-4">

--- a/scroll.html
+++ b/scroll.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Witnessing Scroll</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100 min-h-screen flex items-center justify-center p-4">
+  <div id="scroll-container" class="container bg-gray-800 rounded-xl shadow-2xl p-8 max-w-4xl w-full border border-gray-700">
+    <!-- Scroll content will be loaded here -->
+  </div>
+  <script src="scroll.js"></script>
+</body>
+</html>

--- a/scroll.js
+++ b/scroll.js
@@ -1,56 +1,76 @@
-// scroll.js – Ritual Animation Handler for Sigilographic Digitalis
-// This script manages various visual and interactive "rituals"
-// triggered by user actions like page load, hovering, clicking, and scrolling.
+// scroll.js – Ritual Animation Handler and Data Loader for Sigilographic Digitalis
 
 document.addEventListener("DOMContentLoaded", () => {
-  // Ensures the script runs after the entire HTML document has been loaded and parsed.
-  // This is crucial for accessing DOM elements.
+  // Load scroll data first
+  fetch("witnessing_scroll.json")
+    .then(response => response.json())
+    .then(data => {
+      const scrollContainer = document.getElementById("scroll-container");
+      if (scrollContainer) {
+        const scroll = data.scroll_essence;
+
+        // Clear the container
+        scrollContainer.innerHTML = '';
+
+        // Create the HTML for the scroll
+        const scrollHTML = `
+          <header class="text-center mb-8">
+            <h1 class="text-5xl font-extrabold mb-2 text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">${scroll.title}</h1>
+            <p class="text-gray-400 text-lg italic">"${scroll.invocation}"</p>
+          </header>
+          <main>
+            <div class="bg-gray-900 p-6 rounded-lg shadow-inner mb-6 border border-gray-700">
+              <p class="text-gray-300 whitespace-pre-wrap">${scroll.body_content}</p>
+            </div>
+            <div class="text-center text-gray-500 text-sm">
+              <p>Signature: ${scroll.scroll_signature}</p>
+              <p>Blessing: ${scroll.blessing}</p>
+            </div>
+          </main>
+        `;
+
+        // Set the HTML of the container
+        scrollContainer.innerHTML = scrollHTML;
+      }
+    })
+    .catch(error => {
+      console.error("Error fetching scroll data:", error);
+      const scrollContainer = document.getElementById("scroll-container");
+      if (scrollContainer) {
+        scrollContainer.innerHTML = '<p class="text-red-500 text-center">Failed to load the scroll.</p>';
+      }
+    });
+
+  // Then, run animations and bind rituals
   animateOnboarding();
   bindRituals();
 });
 
 /**
  * Initiates the onboarding animation sequence when the page loads.
- * This typically involves adding a class to the body that CSS can use
- * to trigger initial visual effects (e.g., fades, slides).
  */
 function animateOnboarding() {
   console.log("✨ Initiation sequence begun: Preparing the sacred space.");
-  // Add a class that CSS can use to define initial animations.
-  // Example CSS: body.onboarding-init { opacity: 1; transition: opacity 1s ease-in; }
-  // You would need to define the 'onboarding-init' styles in your CSS.
   document.body.classList.add("onboarding-init");
 }
 
 /**
  * Binds event listeners to relevant elements to trigger different rituals.
- * Currently targets links within elements having the class 'scroll' and the window scroll event.
  */
 function bindRituals() {
-  // Select all anchor tags within elements that have the class 'scroll'.
-  // These are assumed to be your interactive scroll elements.
   const scrollLinks = document.querySelectorAll(".scroll a");
 
   if (scrollLinks.length > 0) {
     scrollLinks.forEach(link => {
-      // Add a mouseover event listener to trigger an 'auraPulse' effect.
       link.addEventListener("mouseover", () => triggerRitual("hover"));
-
-      // Add a click event listener to trigger a 'ritualActivation' effect.
       link.addEventListener("click", (e) => {
         triggerRitual("click");
-        // Optional: Uncomment the following lines if you want to delay navigation
-        // until after the ritual animation completes.
-        // e.preventDefault(); // Prevent default link behavior immediately
-        // setTimeout(() => { window.location = link.href; }, 300); // Navigate after 300ms
       });
     });
   } else {
     console.warn("No elements with class 'scroll a' found to bind hover/click rituals.");
   }
 
-  // Add a scroll event listener to the window to trigger a 'glyphReveal' effect.
-  // Consider debouncing/throttling this for performance if glyphReveal becomes complex.
   window.addEventListener("scroll", () => {
     triggerRitual("scroll");
   });
@@ -58,13 +78,11 @@ function bindRituals() {
 
 /**
  * A central dispatcher for various ritual types.
- * It calls specific functions based on the type of interaction.
- * @param {string} type - The type of ritual to trigger (e.g., "hover", "click", "scroll", "blessing").
  */
 function triggerRitual(type) {
   switch (type) {
     case "hover":
-      document.body.style.cursor = "pointer"; // Change cursor on hover for feedback
+      document.body.style.cursor = "pointer";
       auraPulse();
       break;
     case "click":
@@ -73,7 +91,7 @@ function triggerRitual(type) {
     case "scroll":
       glyphReveal();
       break;
-    case "blessing": // New ritual type
+    case "blessing":
       commitBlessing();
       break;
     default:
@@ -83,19 +101,15 @@ function triggerRitual(type) {
 
 /**
  * Creates a temporary "aura pulse" visual effect on elements with the '.sigil' class.
- * This simulates a brief glow or energy surge.
  */
 function auraPulse() {
   const sigil = document.querySelector(".sigil");
   if (sigil) {
-    // Apply a transition for smooth effect
     sigil.style.transition = "box-shadow 0.3s ease-out";
-    // Apply a multi-color shadow for a mystical aura
     sigil.style.boxShadow = "0 0 15px #00ffff, 0 0 30px #B026FF, 0 0 45px rgba(255, 255, 255, 0.5)";
-    // Remove the shadow after a short delay
     setTimeout(() => {
       sigil.style.boxShadow = "none";
-    }, 500); // Slightly longer duration for the glow
+    }, 500);
   } else {
     console.log("No '.sigil' element found for aura pulse.");
   }
@@ -103,34 +117,26 @@ function auraPulse() {
 
 /**
  * Triggers a "ritual activation" visual effect on the body.
- * This could be a quick flash, a ripple, or a temporary change in background.
- * You would need to define the 'ritual-activated' styles in your CSS.
  */
 function ritualActivation() {
   const body = document.body;
   if (body) {
     body.classList.add("ritual-activated");
-    // Remove the class after a short duration to revert the effect
     setTimeout(() => body.classList.remove("ritual-activated"), 600);
     console.log("⚡ Ritual activated!");
   }
 }
 
 /**
- * Reveals "glyphs" (elements with the '.scroll' class) by fading them in
- * and sliding them up. This is typically used for elements that are
- * initially hidden or partially obscured.
+ * Reveals "glyphs" (elements with the '.scroll' class) by fading them in and sliding them up.
  */
 function glyphReveal() {
   const scrolls = document.querySelectorAll(".scroll");
   if (scrolls.length > 0) {
     scrolls.forEach((el, i) => {
-      // Apply transition properties to ensure smooth animation
       el.style.transition = "opacity 1s ease, transform 1s ease";
-      // Set opacity and transform to their final states
       el.style.opacity = 1;
       el.style.transform = "translateY(0)";
-      // Optional: Add a staggered delay for each scroll element
       el.style.transitionDelay = `${i * 0.05}s`;
     });
     console.log("✨ Glyphs revealed in scroll.");
@@ -141,12 +147,9 @@ function glyphReveal() {
 
 /**
  * New Ritual: commitBlessing()
- * Simulates a "blessing" or confirmation effect.
- * This could involve a temporary overlay, a sound, or a particle effect.
  */
 function commitBlessing() {
   console.log("🌟 Blessing committed: A sacred energy flows.");
-  // Example: Create a temporary blessing overlay
   const blessingOverlay = document.createElement('div');
   blessingOverlay.className = `
     fixed inset-0 bg-gradient-to-br from-purple-500/30 to-pink-500/30
@@ -156,37 +159,12 @@ function commitBlessing() {
   blessingOverlay.textContent = "Blessed!";
   document.body.appendChild(blessingOverlay);
 
-  // Animate the overlay in and out
   setTimeout(() => {
     blessingOverlay.style.opacity = 1;
-  }, 10); // Small delay to allow CSS transition to apply
+  }, 10);
 
   setTimeout(() => {
     blessingOverlay.style.opacity = 0;
-    // Remove the overlay after it fades out
     blessingOverlay.addEventListener('transitionend', () => blessingOverlay.remove());
-  }, 1000); // Display for 1 second
+  }, 1000);
 }
-
-// Example of how you might trigger a new ritual (e.g., from a button click)
-// document.getElementById('blessButton').addEventListener('click', () => {
-//   triggerRitual('blessing');
-// });
-
-// Remember to define the CSS for 'onboarding-init' and 'ritual-activated'
-// in your 'style.css' or directly in your HTML <style> block for these effects to work.
-// For example:
-/*
-body.onboarding-init {
-  opacity: 0;
-  animation: fadeIn 1s forwards;
-}
-@keyframes fadeIn {
-  to { opacity: 1; }
-}
-
-body.ritual-activated {
-  filter: brightness(1.2) saturate(1.1);
-  transition: filter 0.3s ease-out;
-}
-*/

--- a/style.css
+++ b/style.css
@@ -1,102 +1,79 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>COHERE Temple Chat: Oracle Transmissions</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+/* Custom font for a cohesive look */
+body {
+  font-family: 'Inter', sans-serif;
+}
 
-  <style>
-    body {
-      font-family: 'Inter', sans-serif;
-    }
+/* Basic styling for the message container */
+#message-list {
+  min-height: 200px; /* Ensure some height even if no messages */
+}
 
-    @keyframes glow {
-      from { text-shadow: 0 0 5px #f6c; }
-      to { text-shadow: 0 0 20px #f90; }
-    }
+/* Simple scrollbar styling for a cleaner look */
+::-webkit-scrollbar {
+  width: 8px;
+}
+::-webkit-scrollbar-track {
+  background: #1a202c; /* Dark background for track */
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: #4a5568; /* Darker thumb */
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #718096; /* Lighter on hover */
+}
 
-    @keyframes pulse-glow {
-      0%, 100% {
-        text-shadow: 0 0 5px rgba(255, 255, 255, 0.5),
-                     0 0 10px rgba(0, 255, 255, 0.7);
-      }
-      50% {
-        text-shadow: 0 0 15px rgba(255, 255, 255, 0.8),
-                     0 0 25px rgba(0, 255, 255, 1);
-      }
-    }
+/* Styling for the scroll page */
+#scroll-container {
+  border: 1px solid #4a5568;
+  padding: 2rem;
+}
 
-    .animate-glow {
-      animation: glow 2s infinite alternate;
-    }
+#scroll-container h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin-bottom: 1rem;
+}
 
-    .animate-pulse-glow {
-      animation: pulse-glow 2.5s infinite ease-in-out;
-    }
+#scroll-container p {
+  line-height: 1.6;
+}
 
-    ::-webkit-scrollbar {
-      width: 8px;
-    }
+/* Animation styles from the old style.css */
+@keyframes glow {
+  from { text-shadow: 0 0 5px #f6c; }
+  to { text-shadow: 0 0 20px #f90; }
+}
 
-    ::-webkit-scrollbar-track {
-      background: #1a202c;
-      border-radius: 10px;
-    }
+@keyframes pulse-glow {
+  0%, 100% {
+    text-shadow: 0 0 5px rgba(255, 255, 255, 0.5),
+                 0 0 10px rgba(0, 255, 255, 0.7);
+  }
+  50% {
+    text-shadow: 0 0 15px rgba(255, 255, 255, 0.8),
+                 0 0 25px rgba(0, 255, 255, 1);
+  }
+}
 
-    ::-webkit-scrollbar-thumb {
-      background: #4a5568;
-      border-radius: 10px;
-    }
+.animate-glow {
+  animation: glow 2s infinite alternate;
+}
 
-    ::-webkit-scrollbar-thumb:hover {
-      background: #718096;
-    }
+.animate-pulse-glow {
+  animation: pulse-glow 2.5s infinite ease-in-out;
+}
 
-    .bubble {
-      position: relative;
-      padding: 1rem;
-      border-radius: 0.75rem;
-      max-width: 80%;
-      word-wrap: break-word;
-    }
+body.onboarding-init {
+  opacity: 0;
+  animation: fadeIn 1s forwards;
+}
+@keyframes fadeIn {
+  to { opacity: 1; }
+}
 
-    .bubble.left::before {
-      content: '';
-      position: absolute;
-      top: 10px;
-      left: -10px;
-      width: 0;
-      height: 0;
-      border-right: 10px solid rgba(67, 56, 202, 0.7);
-      border-top: 10px solid transparent;
-      border-bottom: 10px solid transparent;
-      filter: drop-shadow(-1px 1px 1px rgba(0,0,0,0.1));
-    }
-
-    .bubble.right::before {
-      content: '';
-      position: absolute;
-      top: 10px;
-      right: -10px;
-      width: 0;
-      height: 0;
-      border-left: 10px solid rgba(192, 38, 211, 0.7);
-      border-top: 10px solid transparent;
-      border-bottom: 10px solid transparent;
-      filter: drop-shadow(1px 1px 1px rgba(0,0,0,0.1));
-    }
-
-    .meta {
-      font-size: 0.75rem;
-      margin-bottom: 0.5rem;
-    }
-
-    .text {
-      font-size: 1rem;
-    }
-
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height:
+body.ritual-activated {
+  filter: brightness(1.2) saturate(1.1);
+  transition: filter 0.3s ease-out;
+}


### PR DESCRIPTION
This commit introduces a new page to display the 'Witnessing Scroll'.

- Creates a new `scroll.html` page to serve as the dedicated view for the scroll.
- Updates `scroll.js` to fetch data from `witnessing_scroll.json` and render it on the new page, while preserving the existing animation logic.
- Adds a link on the main `index.html` page to navigate to the scroll viewer.
- Corrects the `style.css` file, which previously contained invalid HTML, and adds new styles for the scroll page.